### PR TITLE
Update rails_pulse gem and add deployment tracking features

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'geocoder'
 gem 'maxminddb'
 gem 'barnes'
 gem 'requestjs-rails'
-gem 'rails_pulse', '0.2.7'
+gem 'rails_pulse'
 
 # Use Redis adapter to run Action Cable in production
 # gem "redis", ">= 4.0.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    action_text-trix (2.1.18)
+    action_text-trix (2.1.19)
       railties
     actioncable (8.1.3)
       actionpack (= 8.1.3)
@@ -91,8 +91,8 @@ GEM
       metrics (~> 0.12)
       traces (~> 0.18)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1244.0)
-    aws-sdk-core (3.246.0)
+    aws-partitions (1.1255.0)
+    aws-sdk-core (3.250.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
@@ -100,25 +100,24 @@ GEM
       bigdecimal
       jmespath (~> 1, >= 1.6.1)
       logger
-    aws-sdk-kms (1.124.0)
-      aws-sdk-core (~> 3, >= 3.244.0)
+    aws-sdk-kms (1.128.0)
+      aws-sdk-core (~> 3, >= 3.248.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.220.0)
-      aws-sdk-core (~> 3, >= 3.244.0)
+    aws-sdk-s3 (1.224.0)
+      aws-sdk-core (~> 3, >= 3.248.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
     aws-sigv4 (1.12.1)
       aws-eventstream (~> 1, >= 1.0.2)
-    barnes (0.1.0)
+    barnes (1.0.1)
       json
       logger
       ostruct
-      statsd-ruby (~> 1.1)
     base64 (0.3.0)
     bcrypt (3.1.22)
     bigdecimal (4.1.2)
     bindex (0.8.1)
-    bootsnap (1.24.1)
+    bootsnap (1.24.5)
       msgpack (~> 1.2)
     brakeman (8.0.4)
       racc
@@ -135,7 +134,7 @@ GEM
     cgi (0.5.1)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
-    console (1.34.3)
+    console (1.35.1)
       fiber-annotation
       fiber-local (~> 1.1)
       json
@@ -146,7 +145,7 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     device_detector (1.1.3)
-    devise (5.0.3)
+    devise (5.0.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 7.0)
@@ -182,17 +181,17 @@ GEM
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
     io-console (0.8.2)
-    io-event (1.15.1)
+    io-event (1.16.1)
     irb (1.18.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    jbuilder (2.14.1)
+    jbuilder (2.15.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
     jmespath (1.6.2)
-    json (2.19.4)
+    json (2.19.7)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -210,7 +209,7 @@ GEM
       faraday (~> 2.1)
       rack (>= 1.4.0)
       yajl-ruby
-    marcel (1.1.0)
+    marcel (1.2.1)
     matrix (0.4.3)
     maxminddb (0.1.22)
     metrics (0.15.0)
@@ -221,7 +220,7 @@ GEM
       prism (~> 1.5)
     mocha (3.1.0)
       ruby2_keywords (>= 0.0.5)
-    msgpack (1.8.0)
+    msgpack (1.8.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
     net-imap (0.6.4)
@@ -266,7 +265,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (8.0.1)
+    puma (8.0.2)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
@@ -298,12 +297,11 @@ GEM
     rails-html-sanitizer (1.7.0)
       loofah (~> 2.25)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
-    rails_pulse (0.2.7)
+    rails_pulse (0.3.2)
       async (~> 2.0)
       rails (>= 7.1.0, < 9.0.0)
       ransack (~> 4.0)
       request_store (~> 1.5)
-      turbo-rails (~> 2.0.11)
     railties (8.1.3)
       actionpack (= 8.1.3)
       activesupport (= 8.1.3)
@@ -364,10 +362,10 @@ GEM
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
-    rubyzip (3.3.0)
+    rubyzip (3.3.1)
     safely_block (1.0.0)
     securerandom (0.4.1)
-    selenium-webdriver (4.43.0)
+    selenium-webdriver (4.44.0)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
@@ -387,7 +385,6 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
-    statsd-ruby (1.5.0)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.2.0)
@@ -428,7 +425,7 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yajl-ruby (1.4.3)
-    zeitwerk (2.7.5)
+    zeitwerk (2.8.2)
 
 PLATFORMS
   aarch64-linux
@@ -459,7 +456,7 @@ DEPENDENCIES
   pg (~> 1.6)
   puma (>= 5.0)
   rails (~> 8.1.0)
-  rails_pulse (= 0.2.7)
+  rails_pulse
   requestjs-rails
   rubocop-rails-omakase
   selenium-webdriver

--- a/config/initializers/rails_pulse.rb
+++ b/config/initializers/rails_pulse.rb
@@ -100,7 +100,7 @@ RailsPulse.configure do |config|
   # Supports ActiveJob, Sidekiq, and Delayed Job.
 
   # Enable or disable background job tracking
-  config.track_jobs = true
+  config.track_jobs = false
 
   # Thresholds for job execution times (in milliseconds)
   config.job_thresholds = {

--- a/db/migrate/20260426000001_create_rails_pulse_deployments.rb
+++ b/db/migrate/20260426000001_create_rails_pulse_deployments.rb
@@ -1,0 +1,23 @@
+# Add rails_pulse_deployments table for tracking deployment events
+class CreateRailsPulseDeployments < ActiveRecord::Migration[7.0]
+  def up
+    unless table_exists?(:rails_pulse_deployments)
+      create_table :rails_pulse_deployments do |t|
+        t.string   :revision,    null: false, comment: "Git SHA, tag, or version string"
+        t.datetime :started_at,  null: false, comment: "When the deployment started"
+        t.datetime :finished_at,             comment: "When the deployment finished (nil if still in progress or unknown)"
+        t.text     :metadata,                comment: "JSON object of arbitrary deployment metadata"
+        t.timestamps
+      end
+
+      add_index :rails_pulse_deployments, :started_at,
+        name: "index_rails_pulse_deployments_on_started_at"
+      add_index :rails_pulse_deployments, :revision,
+        name: "index_rails_pulse_deployments_on_revision"
+    end
+  end
+
+  def down
+    drop_table :rails_pulse_deployments if table_exists?(:rails_pulse_deployments)
+  end
+end

--- a/db/migrate/20260507000001_add_actual_query_to_operations.rb
+++ b/db/migrate/20260507000001_add_actual_query_to_operations.rb
@@ -1,0 +1,24 @@
+class AddActualQueryToOperations < ActiveRecord::Migration[7.0]
+  def up
+    unless column_exists?(:rails_pulse_operations, :actual_sql)
+      add_column :rails_pulse_operations, :actual_sql, :text,
+        comment: "Actual SQL that ran for sql operations — comment-stripped, unparameterized, unbounded"
+    end
+
+    return unless table_exists?(:rails_pulse_operations)
+
+    # Backfill actual_sql from label for existing sql operations.
+    # NOTE: On MySQL installations that hit the 255-char truncation bug,
+    # actual_sql will contain a partial SQL string — the full query is unrecoverable.
+    # The associated query.normalized_sql is unaffected and analysis still works.
+    RailsPulse::Operation
+      .where(operation_type: "sql", actual_sql: nil)
+      .in_batches(of: 1000) do |batch|
+        batch.update_all("actual_sql = label")
+      end
+  end
+
+  def down
+    remove_column :rails_pulse_operations, :actual_sql if column_exists?(:rails_pulse_operations, :actual_sql)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_20_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_07_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -107,6 +107,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_20_000001) do
     t.index ["user_id"], name: "index_enrollments_on_user_id"
   end
 
+  create_table "rails_pulse_deployments", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "finished_at", comment: "When the deployment finished (nil if still in progress or unknown)"
+    t.text "metadata", comment: "JSON object of arbitrary deployment metadata"
+    t.string "revision", null: false, comment: "Git SHA, tag, or version string"
+    t.datetime "started_at", null: false, comment: "When the deployment started"
+    t.datetime "updated_at", null: false
+    t.index ["revision"], name: "index_rails_pulse_deployments_on_revision"
+    t.index ["started_at"], name: "index_rails_pulse_deployments_on_started_at"
+  end
+
   create_table "rails_pulse_job_runs", force: :cascade do |t|
     t.string "adapter", comment: "Queue adapter"
     t.text "arguments", comment: "Serialized arguments"
@@ -149,6 +160,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_20_000001) do
   end
 
   create_table "rails_pulse_operations", force: :cascade do |t|
+    t.text "actual_sql", comment: "Actual SQL that ran for sql operations — comment-stripped, unparameterized, unbounded"
     t.boolean "cache_hit", default: false, null: false
     t.string "codebase_location", comment: "File and line number (e.g., app/models/user.rb:25)"
     t.datetime "created_at", null: false


### PR DESCRIPTION
Upgrade the `rails_pulse` gem to the latest version and introduce a new database table for tracking deployment events. Disable background job tracking in the configuration and add a new column to store actual SQL queries for operations. Update various gem dependencies to their latest versions.